### PR TITLE
Add reduceToObj function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 import * as K from 'extract-react-types'
 */
 
-import { resolveToLast, resolveFromGeneric } from './utils';
+import { resolveToLast, resolveFromGeneric, reduceToObj } from './utils';
 
 const unaryWhiteList = ['-', '+', '!'];
 
@@ -346,4 +346,4 @@ function convert(type /*: any */, mode /*: string*/ = 'value') {
 }
 
 export default convert;
-export { getKind, resolveFromGeneric };
+export { getKind, resolveFromGeneric, reduceToObj };

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,14 +29,20 @@ export function resolveFromGeneric(type) {
 }
 
 export function reduceToObj(type) {
-  if (type.kind === "generic") {
-    return reduceToObj(type.value);
-  } else if (type.kind === "object") {
+  const reducableKinds = ['generic', 'object', 'intersection'];
+  if (type.kind === 'generic') {
+    // Only attempt to reduce generic if it has a reducable value
+    // Unreducable generics that have an identifier value, e.g. ElementConfig, are still valid
+    // so we return early to avoid the console warn below
+    return reducableKinds.includes(type.value.kind)
+      ? reduceToObj(type.value)
+      : [];
+  } else if (type.kind === 'object') {
     return type.members;
-  } else if (type.kind === "intersection") {
+  } else if (type.kind === 'intersection') {
     return type.types.reduce((acc, i) => [...acc, ...reduceToObj(i)], []);
   }
-  // eslint-disable-next-line no-console
-  console.warn("was expecting to reduce to an object and could not", type);
+
+  console.warn('was expecting to reduce to an object and could not', type);
   return [];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,3 +27,16 @@ export function resolveFromGeneric(type) {
   }
   return type.value;
 }
+
+export function reduceToObj(type) {
+  if (type.kind === "generic") {
+    return reduceToObj(type.value);
+  } else if (type.kind === "object") {
+    return type.members;
+  } else if (type.kind === "intersection") {
+    return type.types.reduce((acc, i) => [...acc, ...reduceToObj(i)], []);
+  }
+  // eslint-disable-next-line no-console
+  console.warn("was expecting to reduce to an object and could not", type);
+  return [];
+}


### PR DESCRIPTION
I was slightly tweaking the [`reduceToObj` function in pretty-prop-types](https://github.com/Noviny/pretty-proptypes/blob/master/src/reduceToObj.js#L4-L5) and saw a comment to extract it to this repo so I've done that.

I'm adding support for being able to spread generics that can't be resolved to objects to extract-react-types and pretty-prop-types so I've updated the function to not console.warn when encountering a non-reducable generic.