### PR TITLE
Add converters for typeParam and typeParamsDeclaration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -291,8 +291,10 @@ const converters = {
 
   nullable: (type /*: K.Nullable */, mode /*: string */) /*: string*/ =>
     `?${convert(type.arguments)}`,
+  typeParam: (type /*: K.TypeParam */, mode /*: string */) /*: string*/ => `${type.name}`,
   typeParams: (type /*: K.TypeParams */, mode /*: string */) /*: string*/ =>
     `<${mapConvertAndJoin(type.params, ', ')}>`,
+  typeParamsDeclaration: (type /*: K.TypeParamsDeclaration */, mode /*: string */) /*: string*/ => `<${mapConvertAndJoin(type.params, ', ')}>`,
   typeof: (type /*: K.Typeof */, mode /*: string */) /*: string*/ => {
     return type.name ? `typeof ${type.name}` : `${type.type.kind}`;
   },

--- a/test.js
+++ b/test.js
@@ -299,9 +299,21 @@ describe('kind 2 string tests', () => {
         expect(final).toBe(`a: [string, number]`);
       });
     });
+    describe('type params', () => {
+      it('should return a string representation of a function type with type params', () => {
+        let prop = '(<T>) => <T><string>';
+        let file = `
+        type Foo<T> = (bar: T) => T;
+        class Component extends React.Component<{ a: Foo<string> }> {}
+        `;
+        let res = extractReactTypes(file, 'flow');
+        let final = convert(res.classes[0].members[0].value);
+        expect(final).toBe(prop);
+      });
+    });
   });
   describe('arrayType', () => {
-    it('should convert the array syntix to a string', () => {
+    it('should convert the array syntax to a string', () => {
       let prop = `number[]`;
       let final = getSingleProp(prop);
       expect(final).toBe('Array of number');


### PR DESCRIPTION
This PR adds converters for the `tyepParam` and `typeParamsDeclaration` kinds added to extract-react-types in https://github.com/atlassian/extract-react-types/pull/25.

The parsed representation of `typeParamsDeclaration` from extract-react-types isn't quite correct so it looks a bit strange, however, I think this is better than nothing.